### PR TITLE
Fix multiple init logger causes panic problem

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,7 @@ export interface CompatBox {
   filePath: string
   astNode: AstNode
 }
+export declare function checkBrowserSupportedWithSourceCode(target: string, sourceCode: string): Array<CompatBox>
 export declare function checkBrowserSupported(target: string, options?: Options | undefined | null): Array<CompatBox>
 export interface Response {
   rawValue: string

--- a/index.js
+++ b/index.js
@@ -310,8 +310,9 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { checkBrowserSupported, getDangerStringsUsage, getModuleMemberUsage } = nativeBinding
+const { checkBrowserSupportedWithSourceCode, checkBrowserSupported, getDangerStringsUsage, getModuleMemberUsage } = nativeBinding
 
+module.exports.checkBrowserSupportedWithSourceCode = checkBrowserSupportedWithSourceCode
 module.exports.checkBrowserSupported = checkBrowserSupported
 module.exports.getDangerStringsUsage = getDangerStringsUsage
 module.exports.getModuleMemberUsage = getModuleMemberUsage

--- a/src/check_browser_supported/mod.rs
+++ b/src/check_browser_supported/mod.rs
@@ -50,7 +50,7 @@ pub fn check_browser_supported_with_source_code(
   let env =
     Env::default().filter_or("SHINED_SOURCE_CODE_DIAGNOSIS_LOG", "info");
 
-  env_logger::init_from_env(env);
+  let _ = env_logger::try_init_from_env(env);
 
   debug!("User-specified browser target: {}", target);
 
@@ -161,7 +161,7 @@ pub fn check_browser_supported(
   let env =
     Env::default().filter_or("SHINED_SOURCE_CODE_DIAGNOSIS_LOG", "info");
 
-  env_logger::init_from_env(env);
+  let _ = env_logger::try_init_from_env(env);
 
   debug!("User-specified browser target: {}", target);
 


### PR DESCRIPTION
- fix: CheckBrowserSupportedWithSourceCode not being exported
- fix: Multiple init logger causes panic problem